### PR TITLE
fix(css): no underline on links wrapping block typography

### DIFF
--- a/public/css/base/typography.css
+++ b/public/css/base/typography.css
@@ -84,6 +84,16 @@
     color: var(--accent-color);
   }
 
+  /*
+   * Links wrapping block-level typography (card-as-link, hero-as-link, etc.)
+   * should not underline their contents. Underline is a signal for inline
+   * text links — not for whole-region tap targets. Covers headings,
+   * paragraphs, and buttons inside any anchor.
+   */
+  a:has(h1, h2, h3, h4, h5, h6, p, button) {
+    text-decoration: none;
+  }
+
   ul[class],
   ol[class] {
     list-style: none;


### PR DESCRIPTION
## Summary

- Adds `a:has(h1,h2,h3,h4,h5,h6,p,button) { text-decoration: none }` to `public/css/base/typography.css`.
- Stops the global underline cascade on whole-card / whole-region links (NuxtLink wrapping a card `<div>`).
- Underline stays on inline text links (the existing `a:not([class])` rule is untouched).

## Why

Card-as-link patterns (custom infographic card, etc.) wrap a `<div>` in a `<NuxtLink>` → renders `<a>` with no class → matches the global `a:not([class]) { text-decoration: underline }` rule → underline propagates to `h3`, `p`, and `bar-button` text inside the card. Reported on `/region/at?topic=foreign-aid&archived=false&activeTab=2`.

Underline is a signal for inline text links. Whole-region tap targets shouldn't inherit it.

## Browser support

`:has()` works in Safari 15.4+, Chrome 105+, Firefox 121+ — all evergreen browsers.

## Test plan

- [ ] Visual: `/region/at?topic=foreign-aid&archived=false&activeTab=2` — custom infographic card heading + description + Download button no longer underlined.
- [ ] Visual: inline links inside paragraphs still show underline.
- [ ] Deploy preview ready on Netlify before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)