### PR TITLE
fix(css): bump no-underline rule specificity to beat a:not([class])

### DIFF
--- a/public/css/base/typography.css
+++ b/public/css/base/typography.css
@@ -86,12 +86,18 @@
 
   /*
    * Links wrapping block-level typography (card-as-link, hero-as-link, etc.)
-   * should not underline their contents. Underline is a signal for inline
-   * text links — not for whole-region tap targets. Covers headings,
-   * paragraphs, and buttons inside any anchor.
+   * should not underline their contents and should not flip color on hover.
+   * Underline + hover color is a signal for inline text links — not for
+   * whole-region tap targets.
+   *
+   * Selectors chain `:not([class])` to beat the base `a:not([class])` rule
+   * (specificity 0,1,1). With `:not([class]):has(...)` we get 0,1,2, and
+   * the `:hover` variant gets 0,2,2 to beat the base hover rule (0,2,1).
    */
-  a:has(h1, h2, h3, h4, h5, h6, p, button) {
+  a:not([class]):has(h1, h2, h3, h4, h5, h6, p, button),
+  a:not([class]):has(h1, h2, h3, h4, h5, h6, p, button):hover {
     text-decoration: none;
+    color: inherit;
   }
 
   ul[class],


### PR DESCRIPTION
## Summary

Follow-up to #11. The `a:has(...)` rule landed but its specificity (0,0,2) lost to the existing `a:not([class])` rule (0,1,1) — underline kept rendering on card-as-link.

- Chain `:not([class])` onto the new rule → 0,1,2 (beats 0,1,1).
- Add explicit `:hover` variant → 0,2,2 (beats `a:not([class]):hover` at 0,2,1) so the accent-color hover also stops on whole-card links.
- Add `color: inherit` so heading/paragraph text isn't tinted by `--link-color` / `--accent-color`.

## Test plan

- [ ] Visual: `/region/at?topic=foreign-aid&archived=false&activeTab=2` — custom infographic card heading + description + Download button no longer underlined, no color flip on hover.
- [ ] Visual: inline links inside paragraphs still underlined + still flip color on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)