### PR TITLE
BF-65: customInfographic mimetype guard

### DIFF
--- a/_process/BF-65/browser-test-report.md
+++ b/_process/BF-65/browser-test-report.md
@@ -1,0 +1,72 @@
+# BF-65 Browser test — report
+
+## Outcome
+
+**BLOCKED — cannot run an end-to-end browser test in this environment.** Falling back to the unit-test layer, which exercises the same DOM-level assertions a browser would.
+
+## Pages requested by the task
+
+1. Primary: `http://localhost:3000/region/united-states?topic=transatlantic-trade` — "Balance of Trade with U.S. (Goods and Services)" customInfographic card (broken-asset case).
+2. Secondary: any healthy customInfographic card (smoke).
+
+## What blocked
+
+### 1. Local dev server unreachable in this run
+
+`npm run dev` (Nuxt 3.21.6, Vite 7.3.3) returns HTTP 500 for every route with the error:
+
+> `Vite Node IPC socket path not configured.`
+> `vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.`
+
+The `NUXT_VITE_NODE_OPTIONS` env var is set inside `nuxt:vite-node-server`'s `configureServer`, which runs on the SSR Vite server. This project has `ssr: false` in `nuxt.config.ts` (line 154) — so the SSR Vite server is never created and that env var is never injected — but the dev Nitro renderer still attempts to call into Vite Node when serving the dev shell, hitting the missing-socket path. This reproduces under every variation tried:
+
+- plain `npm run dev`
+- `node node_modules/.bin/nuxt dev` direct
+- `--no-fork`
+- `NUXT_SSR=true` env override
+- `NUXT_DEVTOOLS=false`
+- stdin redirected from `/dev/null`
+- run under `script(1)` to allocate a pty
+- different ports (3030, 3001) to rule out collision with the parallel new-commons-v2 dev server on 3000
+
+This is a Nuxt 3.21 / `ssr: false` infrastructure incompatibility, **not** a defect introduced by this PR — `git diff origin/dev...HEAD` does not touch dev-server config.
+
+### 2. Content cache is empty
+
+The repo migrated to `@nuxt/content` 3.x with a sqlite cache at `.data/content/contents.sqlite`. The cache has the schema (`_content_topics`, etc.) but `SELECT COUNT(*) FROM _content_topics` returns `0`. The legacy `content/topics/*.json` directory referenced in the task brief no longer exists in this branch — content is pulled from Contentful at build/dev time via `npm run pull`, which is explicitly out of scope per the task instructions.
+
+So even if the dev server bug were resolved, the page would render with no topic data and we couldn't visually distinguish "Layer 1 cleaned the URL" vs "Layer 2 caught it at render time".
+
+### 3. No PR deploy preview
+
+PR #13 has only the GitGuardian secret-scan check (success). No Netlify deploy preview is configured for PRs in this repo (`gh api repos/ccmdesign/bfna-barometer-v2/deployments` returns `[]`). Production deploys only run from `main`.
+
+## Fallback verification at the code/test layer
+
+The component-level Vitest spec asserts exactly the DOM facts the task asked us to verify in a browser:
+
+```
+$ npx vitest run tests/components/customInfographic.spec.ts
+ ✓ tests/components/customInfographic.spec.ts (3 tests) 12ms
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+```
+
+The three cases are:
+
+1. `customInfographicFile.url` non-empty → `<img class="custom_infographic-card__image">` renders, no `.empty-state` — matches the healthy-card expectation.
+2. `customInfographicFile.url === ''` → no `<img>`, **no `<a>`** (so we don't link to `""`), `.empty-state` renders with text `"No image available for this infographic."` — matches the broken-card post-fix expectation (Layer 1 outcome).
+3. `customInfographicFile` itself missing → same empty-state outcome (defense-in-depth; this is Layer 2 if Layer 1 hadn't run yet).
+
+The mapper-level spec (`tests/contentful/topicsv2.spec.ts`, 7 tests) covers the upstream half: PDF asset → `url: ''` + `[BF-65]` console.warn; PNG asset → real Contentful Image API URL; missing contentType / missing file → no-throw, `url: ''`, no warn.
+
+Combined, the unit suite covers both layers of the guard the PR introduces. The behavior a real browser would surface (broken card → empty-state; healthy card → image) is mechanically the same as what these tests assert against the rendered Vue DOM.
+
+## Classification
+
+**Test-environment block**, not a code regression. The PR's behaviour is verified at the unit-test level; the end-to-end browser dogfood needs to happen either (a) on a machine where `npm run dev` works (interactive terminal + Contentful creds + a fresh `npm run pull`) or (b) on a `dev`-branch Netlify deploy after the PR merges.
+
+## Recommendation for next phase
+
+- Proceed with the CI → auto-merge loop to `dev`. After the merge, the next automatic Netlify deploy of `dev` will serve the change, and Sam / Aline can verify `/region/united-states?topic=transatlantic-trade` shows the empty-state card.
+- Flag the Vite Node IPC dev-server breakage as a separate ticket. It will hit anyone trying to run `npm run dev` in a non-interactive shell (CI, agents, headless smoke), and the workaround is non-obvious. Likely fix: pin Nuxt to a pre-3.21 patch, or upgrade past the regression once Nuxt ships one.

--- a/_process/BF-65/dev-server-500-response.json
+++ b/_process/BF-65/dev-server-500-response.json
@@ -1,0 +1,19 @@
+{
+  "error": true,
+  "url": "http://localhost:3001/",
+  "statusCode": 500,
+  "statusMessage": "Server Error",
+  "message": "Vite Node IPC socket path not configured.",
+  "stack": [
+    "Vite Node IPC socket path not configured.",
+    "at /Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/@nuxt/vite-builder/dist/vite-node.mjs:34:34)",
+    "at connectSocket (/Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/@nuxt/vite-builder/dist/vite-node.mjs:31:22)",
+    "at sendRequest (/Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/@nuxt/vite-builder/dist/vite-node.mjs:150:24)",
+    "at async file:///Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/.nuxt/dev/index.mjs:5238:13)",
+    "at async renderRoute (/Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/@nuxt/nitro-server/dist/runtime/handlers/renderer.mjs:109:18)",
+    "at async Object.handler (/Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/nitropack/dist/runtime/internal/renderer.mjs:25:21)",
+    "at async file:///Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/h3/dist/index.mjs:2017:19)",
+    "at async Object.callAsync (/Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/unctx/dist/index.mjs:72:16)",
+    "at async Server.toNodeHandle (/Users/claudiomendonca/Documents/GitHub/ccmdesign/ccm-clients/bfna/bfna-barometer-v2-wt/BF-65/node_modules/h3/dist/index.mjs:2316:7)"
+  ]
+}

--- a/_process/BF-65/dev-server-output.txt
+++ b/_process/BF-65/dev-server-output.txt
@@ -1,0 +1,80 @@
+│
+●  Nuxt 3.21.6 (with Nitro 2.13.4, Vite 7.3.3 and Vue 3.5.34)
+
+  ➜ Local:    http://localhost:3001/
+  ➜ Network:  use --host to expose
+
+  ➜ DevTools: press Shift + Option + D in the browser (v3.2.4)
+
+[@nuxt/content] ✔ Processed 4 collections and 0 files in 27.33ms (0 cached, 0 parsed)
+✔ Vite client built in 18ms
+✔ Vite server built in 216ms
+
+ WARN  [1m[33m[@vue/compiler-sfc][0m[33m defineProps is a compiler macro and no longer needs to be imported.[0m
+
+
+[nitro] ✔ Nuxt Nitro server built in 529ms
+ℹ Vite client warmed up in 1ms
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  [request error] [unhandled] [GET] http://localhost:3001/
+
+ 
+[31mℹ Error: Vite Node IPC socket path not configured.[39m
+
+ ⁃ [33m(node_modules/@nuxt/vite-builder/dist/vite-node.mjs:34:34)[39m
+ ⁃ at connectSocket [33m(node_modules/@nuxt/vite-builder/dist/vite-node.mjs:31:22)[39m
+ ⁃ at sendRequest [33m(node_modules/@nuxt/vite-builder/dist/vite-node.mjs:150:24)[39m
+ ⁃ [33m(async file://.nuxt/dev/index.mjs:5238:13)[39m
+ ⁃ at async renderRoute [33m(node_modules/@nuxt/nitro-server/dist/runtime/handlers/renderer.mjs:109:18)[39m
+ ⁃ at async Object.handler [33m(node_modules/nitropack/dist/runtime/internal/renderer.mjs:25:21)[39m
+ ⁃ [33m(async file://node_modules/h3/dist/index.mjs:2017:19)[39m
+ ⁃ at async Object.callAsync [33m(node_modules/unctx/dist/index.mjs:72:16)[39m
+ ⁃ at async Server.toNodeHandle [33m(node_modules/h3/dist/index.mjs:2316:7)[39m
+
+[31m[CAUSE][39m
+Error {
+  stack: 'Vite Node IPC socket path not configured.\n' +
+  'at ./node_modules/@nuxt/vite-builder/dist/vite-node.mjs:34:34)\n' +
+  'at connectSocket (./node_modules/@nuxt/vite-builder/dist/vite-node.mjs:31:22)\n' +
+  'at sendRequest (./node_modules/@nuxt/vite-builder/dist/vite-node.mjs:150:24)\n' +
+  'at async file://./.nuxt/dev/index.mjs:5238:13)\n' +
+  'at async renderRoute (./node_modules/@nuxt/nitro-server/dist/runtime/handlers/renderer.mjs:109:18)\n' +
+  'at async Object.handler (./node_modules/ni'... 524 more characters,
+  message: 'Vite Node IPC socket path not configured.',
+}
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.
+ERROR  [request error] [unhandled] [GET] http://localhost:3001/
+
+ 
+[31mℹ Error: Vite Node IPC socket path not configured.[39m
+
+ ⁃ [33m(node_modules/@nuxt/vite-builder/dist/vite-node.mjs:34:34)[39m
+ ⁃ at connectSocket [33m(node_modules/@nuxt/vite-builder/dist/vite-node.mjs:31:22)[39m
+ ⁃ at sendRequest [33m(node_modules/@nuxt/vite-builder/dist/vite-node.mjs:150:24)[39m
+ ⁃ [33m(async file://.nuxt/dev/index.mjs:5238:13)[39m
+ ⁃ at async renderRoute [33m(node_modules/@nuxt/nitro-server/dist/runtime/handlers/renderer.mjs:109:18)[39m
+ ⁃ at async Object.handler [33m(node_modules/nitropack/dist/runtime/internal/renderer.mjs:25:21)[39m
+ ⁃ [33m(async file://node_modules/h3/dist/index.mjs:2017:19)[39m
+ ⁃ at async Object.callAsync [33m(node_modules/unctx/dist/index.mjs:72:16)[39m
+ ⁃ at async Server.toNodeHandle [33m(node_modules/h3/dist/index.mjs:2316:7)[39m
+
+[31m[CAUSE][39m
+Error {
+  stack: 'Vite Node IPC socket path not configured.\n' +
+  'at ./node_modules/@nuxt/vite-builder/dist/vite-node.mjs:34:34)\n' +
+  'at connectSocket (./node_modules/@nuxt/vite-builder/dist/vite-node.mjs:31:22)\n' +
+  'at sendRequest (./node_modules/@nuxt/vite-builder/dist/vite-node.mjs:150:24)\n' +
+  'at async file://./.nuxt/dev/index.mjs:5238:13)\n' +
+  'at async renderRoute (./node_modules/@nuxt/nitro-server/dist/runtime/handlers/renderer.mjs:109:18)\n' +
+  'at async Object.handler (./node_modules/ni'... 524 more characters,
+  message: 'Vite Node IPC socket path not configured.',
+}

--- a/components/customInfographic.vue
+++ b/components/customInfographic.vue
@@ -1,20 +1,33 @@
 <template>
   <div class="subgrid">
     <div class="custom_infographic-card__wrapper">
-      <NuxtLink 
-        :to="data.customInfographicFile.url"
-        target="_blank">
+      <template v-if="data.customInfographicFile?.url">
+        <NuxtLink
+          :to="data.customInfographicFile.url"
+          target="_blank">
+          <div class="custom_infographic-card">
+            <img :src="data.customInfographicFile.url" :alt="data.title" class="custom_infographic-card__image" loading="lazy">
+            <div class="custom_infographic-card__content | cluster">
+              <div class="custom_infographic-card__content-inner | text-align:left" split-right>
+                <h3>{{ data.title }}</h3>
+                <p>{{ data.infographicDescription }}</p>
+              </div>
+              <bar-button visual="primary" size="s" color="accent" :to="data.customInfographicFile.url" target="_blank">Download</bar-button>
+            </div>
+          </div>
+        </NuxtLink>
+      </template>
+      <template v-else>
         <div class="custom_infographic-card">
-          <img :src="data.customInfographicFile.url" :alt="data.title" class="custom_infographic-card__image" loading="lazy">
           <div class="custom_infographic-card__content | cluster">
             <div class="custom_infographic-card__content-inner | text-align:left" split-right>
               <h3>{{ data.title }}</h3>
               <p>{{ data.infographicDescription }}</p>
             </div>
-            <bar-button visual="primary" size="s" color="accent" :to="data.customInfographicFile.url" target="_blank">Download</bar-button>
+            <div class="empty-state"><p>No image available for this infographic.</p></div>
           </div>
         </div>
-      </NuxtLink>
+      </template>
     </div>
   </div>
 </template>
@@ -46,6 +59,11 @@
 }
 
 .custom_infographic-card__content {
+  padding: var(--space-m);
+}
+
+.empty-state {
+  color: var(--base-color-50-tint);
   padding: var(--space-m);
 }
 </style>

--- a/components/customInfographic.vue
+++ b/components/customInfographic.vue
@@ -1,45 +1,45 @@
 <template>
   <div class="subgrid">
     <div class="custom_infographic-card__wrapper">
-      <template v-if="data.customInfographicFile?.url">
-        <NuxtLink
-          :to="data.customInfographicFile.url"
-          target="_blank">
-          <div class="custom_infographic-card">
-            <img :src="data.customInfographicFile.url" :alt="data.title" class="custom_infographic-card__image" loading="lazy">
-            <div class="custom_infographic-card__content | cluster">
-              <div class="custom_infographic-card__content-inner | text-align:left" split-right>
-                <h3>{{ data.title }}</h3>
-                <p>{{ data.infographicDescription }}</p>
-              </div>
-              <bar-button visual="primary" size="s" color="accent" :to="data.customInfographicFile.url" target="_blank">Download</bar-button>
-            </div>
-          </div>
-        </NuxtLink>
-      </template>
-      <template v-else>
+      <component
+        :is="hasFile ? 'NuxtLink' : 'div'"
+        :to="hasFile ? data.customInfographicFile.url : undefined"
+        :target="hasFile ? '_blank' : undefined">
         <div class="custom_infographic-card">
+          <img
+            v-if="hasFile"
+            :src="data.customInfographicFile.url"
+            :alt="data.title"
+            class="custom_infographic-card__image"
+            loading="lazy">
           <div class="custom_infographic-card__content | cluster">
             <div class="custom_infographic-card__content-inner | text-align:left" split-right>
               <h3>{{ data.title }}</h3>
               <p>{{ data.infographicDescription }}</p>
             </div>
-            <div class="empty-state"><p>No image available for this infographic.</p></div>
+            <bar-button
+              v-if="hasFile"
+              visual="primary" size="s" color="accent"
+              :to="data.customInfographicFile.url" target="_blank">Download</bar-button>
+            <div v-else class="empty-state"><p>No image available for this infographic.</p></div>
           </div>
         </div>
-      </template>
+      </component>
     </div>
   </div>
 </template>
 
 <script setup>
-  const { data } = defineProps({
+  import { computed } from 'vue'
+
+  const props = defineProps({
     data: {
       type: Object,
       required: true
     }
   })
 
+  const hasFile = computed(() => !!props.data?.customInfographicFile?.url)
 </script>
 
 <style scoped lang="scss">

--- a/contentful/topicsv2.js
+++ b/contentful/topicsv2.js
@@ -1,5 +1,18 @@
 const main = require('../contentful/main')
 
+const ALLOWED_IMAGE_CONTENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'image/svg+xml'
+])
+
+const isAllowedImageAsset = (file) => {
+  const ct = file && file.fields && file.fields.file && file.fields.file.contentType
+  return typeof ct === 'string' && ALLOWED_IMAGE_CONTENT_TYPES.has(ct.toLowerCase())
+}
+
 const getMarker = (fields, infographicsList) => {
 
   const labelMarkers = ['customMarkerLabel1', 'customMarkerLabel2', 'customMarkerLabel3']
@@ -173,10 +186,21 @@ const getTopics = async () => {
           }),
           vizCountries: vizCountriesObj,
           vizMarkers: vizMarkersObj,
-          customInfographicFile: {
-            url: item.fields && item.fields.file && item.fields.file ? main.getImageAssetUrl(item.fields.file.fields.file.url) : '',
-            title: item.fields && item.fields.file && item.fields.file.fields ? item.fields.file.fields.title : ''
-          }
+          customInfographicFile: (() => {
+            const file = item.fields && item.fields.file
+            if (file && isAllowedImageAsset(file)) {
+              return {
+                url: main.getImageAssetUrl(file.fields.file.url),
+                title: file.fields.title || ''
+              }
+            }
+            if (file) {
+              console.warn(
+                `[BF-65] Rejecting non-image customInfographic asset for infographic ${item.sys.id}: contentType=${file.fields && file.fields.file && file.fields.file.contentType}`
+              )
+            }
+            return { url: '', title: (file && file.fields && file.fields.title) || '' }
+          })()
         }
       }) : []
     };
@@ -210,3 +234,6 @@ const getTopics = async () => {
 module.exports = async function () {
   return await getTopics();
 }
+
+module.exports.ALLOWED_IMAGE_CONTENT_TYPES = ALLOWED_IMAGE_CONTENT_TYPES
+module.exports.isAllowedImageAsset = isAllowedImageAsset

--- a/docs/plans/BF-65-mimetype-guard.md
+++ b/docs/plans/BF-65-mimetype-guard.md
@@ -1,0 +1,156 @@
+# BF-65 — customInfographic mimetype guard
+
+## Problem
+
+On `/region/united-states?topic=transatlantic-trade`, the "Balance of Trade with U.S. (Goods and Services)" customInfographic card renders a broken `<img>` because a PDF (`content-type: application/pdf`) was uploaded into Contentful's `file` field on a `customInfographic` entry. Browsers cannot render PDFs through `<img src>`, so the card shows a broken-image icon.
+
+The content fix (Zac/Courtney swap the PDF for a PNG/JPG) is **out of scope**. This plan adds a code-side, defense-in-depth guard so a non-image file in this slot can never again produce a broken `<img>`.
+
+## Investigation summary
+
+- **CMS is Contentful, not Directus.** The ticket calls the asset host (`cms.bfna.org`) "Directus", but the import pipeline in this repo reads exclusively from Contentful via the `contentful` SDK (`contentful/main.js:5`). There is no Directus client, no `cms.bfna.org` reference, and the Contentful Image API query string (`?w=2000&fm=webp&q=80&fit=fill`) is appended to every asset URL in `contentful/main.js:372-377` (`getImageAssetUrl`). The `cms.bfna.org` host in the bug ticket is unrelated to how content actually reaches this app — the ground truth is whatever Contentful returns. If a PDF asset is also reachable as a Contentful asset, the broken card means Contentful itself is serving that asset.
+- **The data path** for a customInfographic image is:
+  1. Build-time pull: `npm run pull` runs `contentImporter.js`, which calls `contentful/topicsv2.js` (the active mapper — `topics.js` is the older variant not wired into `contentImporter.js`).
+  2. `getTopics()` in `contentful/topicsv2.js` maps each topic's `fields.infographics`. For a `customInfographic` linked entry, the relevant write is at `contentful/topicsv2.js:176-179`:
+     ```js
+     customInfographicFile: {
+       url: item.fields && item.fields.file && item.fields.file ? main.getImageAssetUrl(item.fields.file.fields.file.url) : '',
+       title: item.fields && item.fields.file && item.fields.file.fields ? item.fields.file.fields.title : ''
+     }
+     ```
+  3. The mapped topic is serialized to `content/topics/<slug>.json` by `main.writeContent` and read by `@nuxt/content` (`content.config.ts`) into the page (`pages/region/[slug].vue:84-117`), passed to `<custom-infographic :data="infgc" />` (line 229).
+  4. `components/customInfographic.vue:8` renders `<img :src="data.customInfographicFile.url" ...>`.
+- **Mimetype is available at import time.** Contentful's Asset shape includes `item.fields.file.fields.file.contentType` (e.g. `image/png`, `application/pdf`) alongside `url`. The current mapper drops it.
+- **No existing placeholder/empty-state component** dedicated to customInfographic. There is a small precedent pattern in `components/barCompareBox.vue:97-101`:
+  ```html
+  <div class="empty-state"><p>No data available for this country.</p></div>
+  ```
+  We will reuse that simple inline pattern — no new shared component.
+- **Render site of broken image is the only render site.** `customInfographic` is rendered only from `pages/region/[slug].vue:229`. The component itself is the only place the `url` becomes an `<img src>`. Other consumers of `infographicType === 'customInfographic'` (`barCompareBox.vue:40, 107`, `utils/csv.js:122`, `pages/region/[slug].vue:85`) skip it explicitly — they never render the image.
+- **No `tests/` directory exists yet.** AGENTS.md prescribes `@nuxt/test-utils` + Vitest. `@nuxt/test-utils` is already in `package.json`. We will create the `tests/` directory with two specs and a `vitest` invocation note in the plan; we will not add a CI step in this change.
+
+## Design
+
+A two-layer guard, kept small:
+
+### Layer 1 (primary): reject non-image files at import time
+
+In `contentful/topicsv2.js`, when mapping `customInfographicFile`, inspect `item.fields.file.fields.file.contentType` and reject anything that is not an image.
+
+- **Allowlist of image content-types** (explicit, not a `startsWith('image/')` regex — we want to be deliberate about what we accept and ignore exotic types):
+  - `image/png`
+  - `image/jpeg`
+  - `image/webp`
+  - `image/gif`
+  - `image/svg+xml`
+- If `contentType` is missing or not in the allowlist, emit:
+  ```js
+  customInfographicFile: { url: '', title: '<original title or ''>' }
+  ```
+  (an empty `url` is exactly the same shape the mapper already emits when `item.fields.file` is missing, so downstream components already handle it as "no asset").
+- Add a single `console.warn` on rejection that includes `infographicId`, the topic id, and the rejected content-type, so future bad uploads surface in the `npm run pull` log.
+- Do **not** swap the URL or generate any placeholder URL; the empty string is the signal.
+
+Why import-time, not render-time: the page is pre-rendered via `nuxt generate` from cached JSON in `content/topics/*.json`. Sniffing at render time would require a runtime HEAD request per card, which is wasteful when we already have the authoritative `contentType` at pull time. Render-time is also the wrong layer because the bug is "bad data made it into the cache," and the cache is what we own.
+
+### Layer 2 (defensive): fall back in the component if `url` is empty
+
+In `components/customInfographic.vue`, guard the `<img>` with a check on `data.customInfographicFile?.url`. If empty:
+- Render the existing empty-state pattern (`<div class="empty-state"><p>No image available for this infographic.</p></div>`).
+- The wrapping `<NuxtLink :to="...">` and the Download button are also gated, so we don't render a link pointing to `""`.
+
+This second layer is cheap (a single `v-if`) and protects against:
+- Pre-existing `content/topics/*.json` files (from older pulls) that have a PDF URL already baked in but the cache hasn't been re-pulled yet.
+- Any future code path that bypasses the mapper.
+
+### What "non-image asset" means in code
+
+Allowlist of Contentful asset `contentType` strings (see Layer 1 above). Not a URL-extension check — extensions on Contentful URLs are not always present and not authoritative. Not a runtime HEAD request — needless network at SSR/SSG time. Not a generic `startsWith('image/')` — explicit allowlist is easier to reason about and excludes oddities like `image/x-icon` we don't need.
+
+### Fallback rendering
+
+Reuse the inline `.empty-state` pattern from `barCompareBox.vue` (lines 98-100). No new component, no new SCSS file. Add a short scoped `.empty-state` style in `customInfographic.vue` matching the existing visual treatment (muted text, padding) — or just rely on global typography. The message: "No image available for this infographic." (UX copy is intentionally bland — this is a defense-in-depth state that should rarely fire in production.)
+
+## Implementation steps
+
+1. **`contentful/topicsv2.js`** — at the top, add a small constant and helper:
+   ```js
+   const ALLOWED_IMAGE_CONTENT_TYPES = new Set([
+     'image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/svg+xml'
+   ]);
+   const isAllowedImageAsset = (file) => {
+     const ct = file && file.fields && file.fields.file && file.fields.file.contentType;
+     return typeof ct === 'string' && ALLOWED_IMAGE_CONTENT_TYPES.has(ct.toLowerCase());
+   };
+   ```
+   Then change the `customInfographicFile` block (around line 176) to:
+   ```js
+   customInfographicFile: (() => {
+     const file = item.fields && item.fields.file;
+     if (file && isAllowedImageAsset(file)) {
+       return {
+         url: main.getImageAssetUrl(file.fields.file.url),
+         title: file.fields.title || ''
+       };
+     }
+     if (file) {
+       console.warn(
+         `[BF-65] Rejecting non-image customInfographic asset for infographic ${item.sys.id}: contentType=${file.fields && file.fields.file && file.fields.file.contentType}`
+       );
+     }
+     return { url: '', title: (file && file.fields && file.fields.title) || '' };
+   })()
+   ```
+2. **`components/customInfographic.vue`** — wrap the existing markup:
+   ```html
+   <template>
+     <div class="subgrid">
+       <div class="custom_infographic-card__wrapper">
+         <template v-if="data.customInfographicFile?.url">
+           <!-- existing NuxtLink + img + content block, unchanged -->
+         </template>
+         <template v-else>
+           <div class="custom_infographic-card">
+             <div class="custom_infographic-card__content | cluster">
+               <div class="custom_infographic-card__content-inner | text-align:left" split-right>
+                 <h3>{{ data.title }}</h3>
+                 <p>{{ data.infographicDescription }}</p>
+               </div>
+               <div class="empty-state"><p>No image available for this infographic.</p></div>
+             </div>
+           </div>
+         </template>
+       </div>
+     </div>
+   </template>
+   ```
+   Keep the existing `<style scoped>` block; optionally add `.empty-state { color: var(--base-color-50-tint); padding: var(--space-m); }` if not inherited.
+3. **`tests/contentful/topicsv2.spec.ts`** — unit test the helper. Two cases minimum:
+   - Given a mocked `item` with `file.fields.file.contentType = 'application/pdf'`, the mapper output sets `customInfographicFile.url === ''`.
+   - Given the same shape with `contentType = 'image/png'`, the output sets `url` to the transformed URL (with the Contentful Image API query string).
+   Extract `isAllowedImageAsset` to be exportable so it can be tested in isolation, or test through the mapper if extraction is too invasive.
+4. **`tests/components/customInfographic.spec.ts`** — component test using `@nuxt/test-utils` + `mountSuspended`:
+   - When `data.customInfographicFile.url` is non-empty, assert an `<img>` is rendered.
+   - When `data.customInfographicFile.url === ''`, assert no `<img>`, no `<a>`/`<NuxtLink>`, and the empty-state message is visible.
+5. **No data re-pull required in the same PR.** The cached `content/topics/*.json` will get re-cleaned the next time `npm run pull` is run. Layer 2 protects the user in the meantime. Mention this explicitly in the PR description so the reviewer doesn't expect a content delta in the diff.
+
+## Out of scope (do not touch)
+
+- The broken Contentful/Directus asset itself. Content team owns the swap.
+- The legacy mapper `contentful/topics.js` (not wired into `contentImporter.js`).
+- Image-source handling for any other component (`barHero`, `barTopicCard`, choropleth/treemap/timeline/ranking infographics, etc.). No generalized image guard.
+- The `getImageAssetUrl` URL transform in `contentful/main.js`. It already correctly no-ops for SVG (the Contentful Image API ignores `fm=webp` for SVG and serves the original), but if SVG turns out to be problematic we revisit in a follow-up — not here.
+- BF-63 / PR #10. Per user's global CLAUDE.md, untouched.
+
+## Open questions for the implementer
+
+1. **SVG inclusion in the allowlist** — Contentful Image API serves SVGs as PNG/WebP when `?fm=webp` is in the URL, but the original SVG can be rendered as `<img>` directly. Including `image/svg+xml` is the safe default; if there's an internal stance against rendering raw SVGs from CMS uploads (XSS concern), drop it from the allowlist. Default: include it.
+2. **Console-warn vs silent in production builds** — `console.warn` runs at build time during `npm run pull`. That's almost certainly what we want (visible in CI logs). If the team wants it suppressed in `nuxt generate` runs that don't re-pull, we can gate it on `process.env.NODE_ENV !== 'production'`, but I'd default to leaving it loud. Default: leave it.
+
+## Critical files
+
+- `contentful/topicsv2.js` (primary guard)
+- `components/customInfographic.vue` (fallback render)
+- `contentful/main.js` (reference: `getImageAssetUrl`)
+- `components/barCompareBox.vue` (reference: `.empty-state` pattern)
+- `content.config.ts` (schema for cached JSON)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "pull": "node ./contentImporter.js",
     "generate": "node ./contentImporter.js && nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@nuxt/content": "^3.5.0",
@@ -40,13 +42,15 @@
   },
   "devDependencies": {
     "@types/vimeo__player": "^2.18.3",
+    "@vue/test-utils": "^2.4.10",
+    "happy-dom": "^15.11.7",
     "postcss": "^8.4.0",
     "postcss-import": "^16.0.0",
     "postcss-preset-env": "^8.0.0",
-    "sass-embedded": "^1.92.1"
+    "sass-embedded": "^1.92.1",
+    "vitest": "^3.2.4"
   },
   "overrides": {
     "http-proxy-3": "1.21.2"
   }
-  
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@types/vimeo__player": "^2.18.3",
+    "@vitejs/plugin-vue": "^6.0.7",
     "@vue/test-utils": "^2.4.10",
     "happy-dom": "^15.11.7",
     "postcss": "^8.4.0",

--- a/tests/components/customInfographic.spec.ts
+++ b/tests/components/customInfographic.spec.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+// Component test for customInfographic.vue.
+//
+// We intentionally avoid `@nuxt/test-utils`' `mountSuspended` (which boots a
+// full Nuxt runtime — overkill, and currently fails in this repo because
+// `app.head.link` preloads `/assets/barometer-logo.svg` through a virtual id
+// Vite refuses to serve under the test runner). Plain `@vue/test-utils` with
+// stubs for the Nuxt-injected components (`NuxtLink`, `bar-button`) is enough
+// to assert the v-if/v-else mimetype-guard branch.
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CustomInfographic from '../../components/customInfographic.vue'
+
+const stubs = {
+  NuxtLink: {
+    name: 'NuxtLink',
+    props: ['to'],
+    template: '<a :href="to"><slot /></a>'
+  },
+  // `bar-button` is auto-imported in dev; render it as a no-op span so the
+  // branch we actually care about (img vs empty-state) is what's asserted.
+  'bar-button': {
+    name: 'BarButton',
+    props: ['to', 'visual', 'size', 'color', 'target'],
+    template: '<a class="bar-button" :href="to"><slot /></a>'
+  }
+}
+
+const baseData = {
+  title: 'Balance of Trade with U.S. (Goods and Services)',
+  infographicDescription: 'Imports vs. exports over the last decade.'
+}
+
+describe('CustomInfographic.vue', () => {
+  it('renders an <img> when customInfographicFile.url is non-empty', () => {
+    const wrapper = mount(CustomInfographic, {
+      global: { stubs },
+      props: {
+        data: {
+          ...baseData,
+          customInfographicFile: {
+            url: 'https://images.ctfassets.net/x/y/balance.png?w=2000&fm=webp&q=80&fit=fill',
+            title: 'Balance'
+          }
+        }
+      }
+    })
+
+    const img = wrapper.find('img.custom_infographic-card__image')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toContain('balance.png')
+    expect(wrapper.find('.empty-state').exists()).toBe(false)
+    expect(wrapper.text()).toContain(baseData.title)
+  })
+
+  it('renders empty-state fallback (no <img>, no <a>) when url is empty', () => {
+    const wrapper = mount(CustomInfographic, {
+      global: { stubs },
+      props: {
+        data: {
+          ...baseData,
+          customInfographicFile: { url: '', title: '' }
+        }
+      }
+    })
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.find('a').exists()).toBe(false)
+    const emptyState = wrapper.find('.empty-state')
+    expect(emptyState.exists()).toBe(true)
+    expect(emptyState.text()).toBe('No image available for this infographic.')
+    // Title and description still render so the card isn't completely blank.
+    expect(wrapper.text()).toContain(baseData.title)
+    expect(wrapper.text()).toContain(baseData.infographicDescription)
+  })
+
+  it('renders empty-state fallback when customInfographicFile itself is missing', () => {
+    const wrapper = mount(CustomInfographic, {
+      global: { stubs },
+      props: {
+        data: { ...baseData }
+      }
+    })
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.find('a').exists()).toBe(false)
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+})

--- a/tests/contentful/topicsv2.spec.ts
+++ b/tests/contentful/topicsv2.spec.ts
@@ -153,6 +153,21 @@ describe('getTopics customInfographicFile mapping', () => {
     expect(infgc.customInfographicFile.title).toBe('')
     expect(warnSpy).not.toHaveBeenCalled()
   })
+
+  it('warns and sets url to empty string when contentType is missing on a present file', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const topic = await runMapper({
+      title: 'Mystery asset',
+      // contentType deliberately omitted — malformed-but-present asset shape.
+      file: { url: '//images.ctfassets.net/x/y/z' } as unknown as AssetFields['file']
+    })
+    expect(topic).not.toBeNull()
+    const infgc = topic!.infographics[0]
+    expect(infgc.customInfographicFile.url).toBe('')
+    expect(infgc.customInfographicFile.title).toBe('Mystery asset')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[BF-65]'))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('contentType=undefined'))
+  })
 })
 
 // silence unused-import warning for Module (kept for clarity that we manipulate it)

--- a/tests/contentful/topicsv2.spec.ts
+++ b/tests/contentful/topicsv2.spec.ts
@@ -1,0 +1,159 @@
+import path from 'node:path'
+import Module from 'node:module'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `contentful/topicsv2.js` is CommonJS and does `require('../contentful/main')`.
+// vi.mock targets the ESM module graph and is NOT honored by Node's CJS loader,
+// so we inject our stub straight into `require.cache` before topicsv2 is loaded.
+const writeContentSpy = vi.fn()
+const getImageAssetUrlSpy = vi.fn((url: string) => `${url}?w=2000&fm=webp&q=80&fit=fill`)
+const contentfulClientStub = { getEntries: vi.fn() }
+
+const mainStub = {
+  contentfulClient: contentfulClientStub,
+  slugify: (s: string) => String(s).toLowerCase().replace(/\s+/g, '-'),
+  formatCountryName: (s: string) => String(s),
+  getCodeByCountry: {} as Record<string, string>,
+  getCodeByCountryCamelCase: {} as Record<string, string>,
+  getImageAssetUrl: (url: string) => getImageAssetUrlSpy(url),
+  writeContent: (item: unknown) => writeContentSpy(item),
+  checkFolder: vi.fn().mockResolvedValue(true)
+}
+
+const repoRoot = path.resolve(__dirname, '..', '..')
+const mainPath = require.resolve(path.join(repoRoot, 'contentful', 'main.js'))
+const topicsv2Path = require.resolve(path.join(repoRoot, 'contentful', 'topicsv2.js'))
+
+// Seed require.cache so any `require('../contentful/main')` resolves to mainStub.
+require.cache[mainPath] = {
+  id: mainPath,
+  filename: mainPath,
+  loaded: true,
+  exports: mainStub,
+  paths: [],
+  children: [],
+  // The CJS Module type expects more fields than we need here.
+} as unknown as NodeJS.Module
+
+// Make sure topicsv2 picks up the seeded main on first require.
+// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+delete require.cache[topicsv2Path]
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const topicsv2 = require(topicsv2Path) as {
+  (): Promise<void>
+  isAllowedImageAsset: (file: unknown) => boolean
+}
+
+type AssetFields = { title?: string, file: { url: string, contentType: string } }
+
+const buildTopicWith = (fileFields: AssetFields | undefined) => {
+  return {
+    sys: { id: 'topic-1' },
+    fields: {
+      topic: 'Transatlantic Trade',
+      description: 'topic desc',
+      period: '2024-01-01',
+      tags: ['trade'],
+      infographics: [
+        {
+          sys: { id: 'cig-1', contentType: { sys: { id: 'customInfographic' } } },
+          fields: {
+            title: 'Balance of Trade',
+            description: 'desc',
+            ...(fileFields ? { file: { sys: { id: 'asset-1' }, fields: fileFields } } : {})
+          }
+        }
+      ]
+    }
+  }
+}
+
+describe('isAllowedImageAsset', () => {
+  it('returns true for allowed image content types', () => {
+    for (const ct of ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/svg+xml']) {
+      expect(topicsv2.isAllowedImageAsset({ fields: { file: { contentType: ct, url: '//x' } } })).toBe(true)
+    }
+  })
+
+  it('returns true case-insensitively', () => {
+    expect(topicsv2.isAllowedImageAsset({ fields: { file: { contentType: 'IMAGE/PNG', url: '//x' } } })).toBe(true)
+  })
+
+  it('returns false for non-image content types', () => {
+    for (const ct of ['application/pdf', 'application/octet-stream', 'text/html', 'image/x-icon', '']) {
+      expect(topicsv2.isAllowedImageAsset({ fields: { file: { contentType: ct, url: '//x' } } })).toBe(false)
+    }
+  })
+
+  it('returns false when contentType is missing', () => {
+    expect(topicsv2.isAllowedImageAsset({ fields: { file: { url: '//x' } } })).toBe(false)
+    expect(topicsv2.isAllowedImageAsset({ fields: {} })).toBe(false)
+    expect(topicsv2.isAllowedImageAsset(null)).toBe(false)
+    expect(topicsv2.isAllowedImageAsset(undefined)).toBe(false)
+  })
+})
+
+describe('getTopics customInfographicFile mapping', () => {
+  beforeEach(() => {
+    writeContentSpy.mockClear()
+    getImageAssetUrlSpy.mockClear()
+    contentfulClientStub.getEntries.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const runMapper = async (fileFields: AssetFields | undefined) => {
+    const topic = buildTopicWith(fileFields)
+    contentfulClientStub.getEntries.mockImplementation((query: { content_type: string }) => {
+      if (query.content_type === 'topics') return Promise.resolve({ items: [topic] })
+      if (query.content_type === 'country') return Promise.resolve({ items: [] })
+      if (query.content_type === 'treemapChart') return Promise.resolve({ items: [] })
+      return Promise.resolve({ items: [] })
+    })
+    await topicsv2()
+    // The forEach inside getTopics is async; flush microtasks before reading writes.
+    await new Promise((resolve) => setImmediate(resolve))
+    const writtenTopic = writeContentSpy.mock.calls.find(([item]) => item && item.id === 'topic-1')
+    return writtenTopic ? writtenTopic[0] : null
+  }
+
+  it('sets url to empty string when the asset contentType is application/pdf', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const topic = await runMapper({
+      title: 'BoT PDF',
+      file: { url: '//images.ctfassets.net/x/y/z.pdf', contentType: 'application/pdf' }
+    })
+    expect(topic).not.toBeNull()
+    const infgc = topic!.infographics[0]
+    expect(infgc.customInfographicFile.url).toBe('')
+    expect(infgc.customInfographicFile.title).toBe('BoT PDF')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[BF-65]'))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('application/pdf'))
+  })
+
+  it('sets url to the Contentful Image API URL when contentType is image/png', async () => {
+    const topic = await runMapper({
+      title: 'BoT PNG',
+      file: { url: '//images.ctfassets.net/x/y/z.png', contentType: 'image/png' }
+    })
+    expect(topic).not.toBeNull()
+    const infgc = topic!.infographics[0]
+    expect(infgc.customInfographicFile.url).toBe('//images.ctfassets.net/x/y/z.png?w=2000&fm=webp&q=80&fit=fill')
+    expect(infgc.customInfographicFile.title).toBe('BoT PNG')
+  })
+
+  it('sets url to empty string when there is no file at all (no warn)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const topic = await runMapper(undefined)
+    expect(topic).not.toBeNull()
+    const infgc = topic!.infographics[0]
+    expect(infgc.customInfographicFile.url).toBe('')
+    expect(infgc.customInfographicFile.title).toBe('')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+// silence unused-import warning for Module (kept for clarity that we manipulate it)
+void Module

--- a/todos/BF-65-declare-vitejs-plugin-vue-dep.md
+++ b/todos/BF-65-declare-vitejs-plugin-vue-dep.md
@@ -1,0 +1,44 @@
+# Declare `@vitejs/plugin-vue` as an explicit devDependency
+
+- **Severity:** P2 (should fix)
+- **Files:**
+  - `vitest.config.ts:2` — `import vue from '@vitejs/plugin-vue'`
+  - `package.json` (devDependencies block)
+
+## Problem
+
+`vitest.config.ts` imports `@vitejs/plugin-vue`, but the package is not listed
+in `package.json`. Right now `npm ls @vitejs/plugin-vue` shows it is provided
+transitively by `@nuxt/vite-builder@3.21.6`:
+
+```
+nuxt-app@
+`-- @nuxt/vite-builder@3.21.6
+  `-- @vitejs/plugin-vue@6.0.7
+```
+
+Relying on a hoisted transitive dep is fragile:
+
+- If Nuxt bumps `@nuxt/vite-builder` and pins or removes that dep, `npm install`
+  will still succeed and the app will still build — but `npm test` will fail with
+  `Cannot find module '@vitejs/plugin-vue'`, which is a confusing failure mode
+  (test infra breaks because of an unrelated Nuxt upgrade).
+- pnpm with `strict-peer-dependencies` / hoist-off, or yarn PnP, would not
+  resolve the transitive at all.
+
+This is exactly the kind of thing that should be declared explicitly when we
+own the consumer (the test config).
+
+## Suggested fix
+
+```bash
+npm install --save-dev @vitejs/plugin-vue
+```
+
+Pin to a version that matches the currently-resolved one (`^6.0.7` is fine).
+Re-run `npm test` to confirm it still passes.
+
+## Why it matters
+
+Defends `npm test` against unrelated Nuxt version churn. Costs one line in
+`package.json` + one line in `package-lock.json`.

--- a/todos/BF-65-declare-vitejs-plugin-vue-dep.md
+++ b/todos/BF-65-declare-vitejs-plugin-vue-dep.md
@@ -1,9 +1,17 @@
 # Declare `@vitejs/plugin-vue` as an explicit devDependency
 
 - **Severity:** P2 (should fix)
+- **Status:** resolved
 - **Files:**
   - `vitest.config.ts:2` — `import vue from '@vitejs/plugin-vue'`
   - `package.json` (devDependencies block)
+
+## Resolution
+
+Added `@vitejs/plugin-vue@^6.0.7` to `devDependencies` via
+`npm install --save-dev @vitejs/plugin-vue@^6.0.7`. `npx vitest run` confirmed
+green (10/10 passing). No longer relying on the hoisted transitive from
+`@nuxt/vite-builder`.
 
 ## Problem
 

--- a/todos/BF-65-dedupe-title-description-markup.md
+++ b/todos/BF-65-dedupe-title-description-markup.md
@@ -1,0 +1,69 @@
+# Dedupe title + description markup across v-if/v-else in customInfographic.vue
+
+- **Severity:** P2 (should fix)
+- **File:** `components/customInfographic.vue:8-29`
+
+## Problem
+
+The v-if and v-else branches duplicate the `<h3>{{ data.title }}</h3>` and
+`<p>{{ data.infographicDescription }}</p>` markup, plus the `cluster` wrapper
+and the `custom_infographic-card` shell. The only real difference between the
+two branches is:
+
+- v-if branch: wrapped in `<NuxtLink>` + has `<img>` + has `<bar-button>`
+  Download
+- v-else branch: no link, no img, replaces the download button with the
+  empty-state `<div>`
+
+If `data.title` styling, the `cluster` modifier, the `split-right` attribute,
+or the inner-content class string ever changes, both branches have to be
+updated in lockstep, and skew between them is invisible until someone opens the
+broken-state card.
+
+## Suggested fix
+
+Render the card shell + title + description once, and only switch the
+download-vs-empty-state slot via v-if. For example:
+
+```html
+<div class="custom_infographic-card__wrapper">
+  <component
+    :is="data.customInfographicFile?.url ? NuxtLinkComponent : 'div'"
+    :to="data.customInfographicFile?.url || undefined"
+    target="_blank">
+    <div class="custom_infographic-card">
+      <img
+        v-if="data.customInfographicFile?.url"
+        :src="data.customInfographicFile.url"
+        :alt="data.title"
+        class="custom_infographic-card__image"
+        loading="lazy">
+      <div class="custom_infographic-card__content | cluster">
+        <div class="custom_infographic-card__content-inner | text-align:left" split-right>
+          <h3>{{ data.title }}</h3>
+          <p>{{ data.infographicDescription }}</p>
+        </div>
+        <bar-button
+          v-if="data.customInfographicFile?.url"
+          visual="primary" size="s" color="accent"
+          :to="data.customInfographicFile.url" target="_blank">Download</bar-button>
+        <div v-else class="empty-state">
+          <p>No image available for this infographic.</p>
+        </div>
+      </div>
+    </div>
+  </component>
+</div>
+```
+
+(Or alternatively keep the v-if/v-else but factor the inner-content block into
+a sub-template / extract a tiny `<CustomInfographicHeader>` component.)
+
+Either way: one source of truth for the title/description block. Re-run the
+existing component spec — both assertions should still pass.
+
+## Why it matters
+
+Removes a quiet drift surface. Future copy or layout changes to the title block
+won't silently miss the empty-state branch. Both component specs already cover
+the v-if and v-else branches, so the refactor is safe.

--- a/todos/BF-65-dedupe-title-description-markup.md
+++ b/todos/BF-65-dedupe-title-description-markup.md
@@ -1,7 +1,18 @@
 # Dedupe title + description markup across v-if/v-else in customInfographic.vue
 
 - **Severity:** P2 (should fix)
+- **Status:** resolved
 - **File:** `components/customInfographic.vue:8-29`
+
+## Resolution
+
+Collapsed the v-if/v-else into a single card shell rendered via
+`<component :is="hasFile ? 'NuxtLink' : 'div'">`. The card body, title (h3),
+and description (p) now have a single source of truth; only the `<img>` and
+the `<bar-button>`-vs-`empty-state` swap remain conditional. Added a small
+`hasFile` computed in `<script setup>` so the template stays readable.
+All three component specs (with image, with empty url, with no
+customInfographicFile) still pass.
 
 ## Problem
 

--- a/todos/BF-65-test-missing-contentType-path.md
+++ b/todos/BF-65-test-missing-contentType-path.md
@@ -1,0 +1,55 @@
+# Add test for "file present but contentType missing" path
+
+- **Severity:** P3 (nice to have)
+- **File:** `tests/contentful/topicsv2.spec.ts`
+
+## Problem
+
+The mapper handles three input shapes for `item.fields.file`:
+
+1. **No file at all** — covered by the "sets url to empty string when there is
+   no file at all (no warn)" test.
+2. **File with allowed image contentType** — covered by the `image/png` test.
+3. **File with rejected/non-allowlisted contentType** — covered by the
+   `application/pdf` test.
+
+Missing: **file is present but `contentType` itself is missing/undefined** (e.g.
+a malformed Contentful asset where `file.fields.file = { url: '//x' }` but
+no `contentType`). The current code path on this input is:
+
+- `isAllowedImageAsset(file)` → `false` (because `typeof undefined !== 'string'`)
+- `if (file)` → `true` → emits the `[BF-65] Rejecting...` warn with
+  `contentType=undefined`
+- returns `{ url: '', title: file.fields.title || '' }`
+
+The `isAllowedImageAsset` unit test covers the false return, but the *mapper-
+level* behavior (warn + empty url, not silent) is not asserted. If someone
+later "optimizes" the `if (file)` warn branch to require a string contentType,
+the regression would not be caught.
+
+## Suggested fix
+
+Add a third case to the `getTopics customInfographicFile mapping` describe
+block:
+
+```ts
+it('warns and sets url to empty string when contentType is missing on a present file', async () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const topic = await runMapper({
+    title: 'Mystery asset',
+    // contentType deliberately omitted
+    file: { url: '//images.ctfassets.net/x/y/z' } as any
+  })
+  expect(topic).not.toBeNull()
+  const infgc = topic!.infographics[0]
+  expect(infgc.customInfographicFile.url).toBe('')
+  expect(infgc.customInfographicFile.title).toBe('Mystery asset')
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[BF-65]'))
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('contentType=undefined'))
+})
+```
+
+## Why it matters
+
+Locks in the "loud on malformed asset" contract end-to-end through the mapper,
+not just the helper. Tiny addition, covers a real shape Contentful can serve.

--- a/todos/BF-65-test-missing-contentType-path.md
+++ b/todos/BF-65-test-missing-contentType-path.md
@@ -1,7 +1,16 @@
 # Add test for "file present but contentType missing" path
 
 - **Severity:** P3 (nice to have)
+- **Status:** resolved
 - **File:** `tests/contentful/topicsv2.spec.ts`
+
+## Resolution
+
+Added a fourth case to the `getTopics customInfographicFile mapping` describe
+block: feeds a present file with no `contentType` and asserts that the mapper
+warns with the `[BF-65]` tag + `contentType=undefined`, returns an empty url,
+and preserves `title`. Locks in the "loud on malformed asset" contract
+end-to-end through the mapper (not just the helper). Suite now 11/11 passing.
 
 ## Problem
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+// Lightweight setup — we do NOT boot a full Nuxt runtime for these tests.
+// Component specs use `@vue/test-utils` directly with stubs for Nuxt-injected
+// components, and the contentful mapper spec runs in Node with require-cache
+// stubs.  Per-file `// @vitest-environment` headers pick happy-dom where the
+// spec touches the DOM.
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.spec.ts']
+  }
+})


### PR DESCRIPTION
## Summary

Defense-in-depth guard so a non-image asset (e.g. an accidentally uploaded PDF) in a Contentful `customInfographic.file` slot can never again render a broken `<img>` on the site. Triggered by `/region/united-states?topic=transatlantic-trade` showing a broken image icon for the "Balance of Trade with U.S. (Goods and Services)" card after a PDF was uploaded into that slot in Contentful.

Plan: [docs/plans/BF-65-mimetype-guard.md](https://github.com/ccmdesign/bfna-barometer-v2/blob/feature/BF-65-mimetype-guard/docs/plans/BF-65-mimetype-guard.md)

## Two-layer design

**Layer 1 — `contentful/topicsv2.js` (primary, build-time):** when the import pipeline maps a `customInfographic` entry, inspect `item.fields.file.fields.file.contentType` and only accept assets whose content type is in an explicit allowlist:

- `image/png`, `image/jpeg`, `image/webp`, `image/gif`, `image/svg+xml`

If the asset is missing or its content type is not in the allowlist, emit `customInfographicFile: { url: '', title: '<original title>' }` and log a `[BF-65]` `console.warn` naming the infographic id and the rejected content type so future bad uploads surface in the `npm run pull` log.

**Layer 2 — `components/customInfographic.vue` (defensive, render-time):** wrap the existing card markup in `<template v-if="data.customInfographicFile?.url">`. The `<template v-else>` branch renders the title + description + a small `.empty-state` "No image available for this infographic." (mirroring the empty-state in `barCompareBox.vue`). No `<a>`/`<img>` are produced in the empty state — so we never link to `""`.

## No content re-pull in this PR

We deliberately do **not** include a `content/topics/*.json` re-pull in this PR. The cached JSON will get re-cleaned the next time `npm run pull` runs (which strips Layer-1-rejected assets to `url: ''`). Layer 2 protects users in the meantime, so this PR's diff is code-only.

## Decisions made on the plan's open questions

1. **`image/svg+xml` in the allowlist** -> **yes** (Contentful Image API handles SVG fine, and there's no internal stance against rendering CMS-uploaded SVGs in this slot).
2. **`console.warn` gated on `NODE_ENV`** -> **no, keep it loud in all builds**. Bad uploads should be visible in CI/build logs.

## Test plan

- [x] `npx vitest run` -> 10/10 pass
  - `tests/contentful/topicsv2.spec.ts` (7 tests): `isAllowedImageAsset` allow/reject/case-insensitivity/missing-contentType + mapper output for `application/pdf` -> `url === ''`, `image/png` -> Contentful Image API URL, no-file -> `url === ''` and no warn.
  - `tests/components/customInfographic.spec.ts` (3 tests): `<img>` renders when `url` non-empty; empty-state renders (no `<img>`, no `<a>`) when `url === ''`; same when `customInfographicFile` is missing.
- [x] `npx eslint "./contentful/topicsv2.js" "./components/customInfographic.vue" "./tests/**/*.spec.ts" "./vitest.config.ts"` -> clean.
- [ ] Manual smoke after merge to `dev`: load `/region/united-states?topic=transatlantic-trade`, confirm the "Balance of Trade with U.S. (Goods and Services)" card renders the empty-state message (no broken image icon). After Content team uploads the replacement PNG/JPG, run `npm run pull` and confirm the image renders normally.

## Out of scope

- Swapping the broken Contentful asset (content team owns).
- `contentful/topics.js` (legacy, not wired into `contentImporter.js`).
- Generalized image guard for other components (`barHero`, `barTopicCard`, choropleth/treemap/timeline/ranking infographics).
- BF-63 / PR #10 untouched.